### PR TITLE
Added safeties to deal with unsafe parameter access

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -219,7 +219,7 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 			objectName = defaultObjectName;
 		}
 //		if (parameter.type.toLowerCase() == "object[]") parameter.type = "Array";
-		var type = parameter.type;
+		var type = parameter.type || "";
 		if (i == 0) {
 			result.topLevelRefType = type;
 			if(parameter.type == "Object") {
@@ -237,7 +237,7 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 			{ properties : {}, required : [] };
 
 		if (nestedName.propertyName) {
-			var prop = { type: (parameter.type.toLowerCase() || "").toLowerCase(), description: removeTags(parameter.description) };
+			var prop = { type: (type.toLowerCase() || "").toLowerCase(), description: removeTags(parameter.description) };
 			var typeIndex = type.indexOf("[]");
 			if(parameter.type == "Object") {
 				prop.$ref = "#/definitions/" + parameter.field;
@@ -284,11 +284,12 @@ function createNestedName(field) {
 function createSchema(fields, definitions, defName, objName){
 	if (!objName) objName = defName;
 	var schema = {};
+	var fieldType = fields[0] ? (fields[0].type || "") : "";
 
 	//looks like createFieldArrayDefinitions treats types with [] differently
-	if (fields[0].type.toLowerCase().indexOf('object') >= 0 || fields[0].type.toLowerCase() == 'array' ){
+	if (fieldType.toLowerCase().indexOf('object') >= 0 || fieldType.toLowerCase() == 'array' ){
 		//if object or array of objects - create object definition
-		if (fields[0].type.toLowerCase() == 'object[]') {
+		if (fieldType.toLowerCase() == 'object[]') {
 			fields[0].type = 'Array';
 		}
 		var fieldArrayResult = createFieldArrayDefinitions(fields, definitions, defName, objName);
@@ -302,20 +303,20 @@ function createSchema(fields, definitions, defName, objName){
 		}
 	} else {
 		//simple type or array of simple type
-		if (fields[0].type.indexOf('[]') >= 0) {
+		if (fieldType.indexOf('[]') >= 0) {
 			schema["type"] = "array";
 			schema["items"] = {
-				"type": fields[0].type.replace('[]', '').toLowerCase()
+				"type": fieldType.replace('[]', '').toLowerCase()
 			};
 		} else {
-			schema["type"] = fields[0].type.toLowerCase();
+			schema["type"] = fieldType.toLowerCase();
 		}
 	}
 	return schema;
 }
 
 function createSuccessResults(verbs, definitions){
-	return _.mapValues(verbs.success.fields, function(success){
+	return _.mapValues(verbs.success ? verbs.success.fields : [], function(success){
 		var result = { "description": "Success" };
 		if (success.length > 0  && success[0].field && success[0].field != 'null'
 				&& success[0].type &&  success[0].type != 'null') {
@@ -326,10 +327,10 @@ function createSuccessResults(verbs, definitions){
 }
 
 function createErrorResults(verbs, definitions){
-	return _.mapValues(verbs.error.fields, function(success){
+	return _.mapValues(verbs.errors ? verbs.error.fields : [], function(err){
 		return {
 			"description": "Error",
-			"schema": createSchema(success, definitions, verbs.name+"Error", verbs.name+"Error")
+			"schema": createSchema(err, definitions, verbs.name+"Error", verbs.name+"Error")
 		}
 	});
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apidoc-swagger",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Convert api doc json to swagger json",
   "author": "Bahman Fakhr Sabahi",
   "license": {


### PR DESCRIPTION
I really like your PR against apidoc-swagger!

While using your upgrades, I encountered some unsafe parameter access patterns that caused the module to crash when invoked against a partially-documented codebase I own. What do you think of these changes?